### PR TITLE
implement RENAME TABLE feature

### DIFF
--- a/src/ha_queue.h
+++ b/src/ha_queue.h
@@ -1,15 +1,15 @@
 /*
  * Copyright (C) 2007,2008 Cybozu Labs, Inc.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; version 2 of the License.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -240,9 +240,9 @@ struct queue_connection_t;
 struct queue_compact_writer;
 
 class queue_share_t {
-  
+
 public:
-  
+
   struct append_t {
     const void *rows;
     size_t rows_size, row_count;
@@ -256,7 +256,7 @@ public:
     append_t& operator=(const append_t&);
   };
   typedef std::vector<append_t*> append_list_t;
-  
+
 #if Q4M_DELETE_METHOD != Q4M_DELETE_SERIAL_PWRITE && defined(FDATASYNC_SKIP)
 #else
   struct remove_t : public dllist<remove_t> {
@@ -270,7 +270,7 @@ public:
 # endif
   };
 #endif
-  
+
   struct cond_expr_t : public dllist<cond_expr_t> {
     queue_cond_t::node_t *node;
     char *expr;
@@ -297,7 +297,7 @@ public:
       delete this;
     }
   };
-  
+
   struct listener_t {
     pthread_cond_t cond;
     queue_connection_t *listener;
@@ -317,7 +317,7 @@ public:
     : l(_l), cond(c), queue_wait_index(qwi) {}
   };
   typedef std::list<listener_cond_t> listener_list_t;
-  
+
   struct info_t {
     queue_file_header_t _header;
     queue_connection_t *rows_owned;
@@ -334,21 +334,21 @@ public:
 #endif
     pthread_cond_t *do_compact_cond;
     bool is_dropping_table;
-    
+
     queue_cond_t cond_eval;
     cond_expr_t *active_cond_exprs;
     cond_expr_t *inactive_cond_exprs;
     size_t inactive_cond_expr_cnt;
     bool writer_exit;
-    
+
     size_t null_bytes;
     size_t fields;
     uchar *fixed_buf;
     size_t fixed_buf_size;
-    
+
     my_off_t rows_written;
     my_off_t rows_removed;
-    
+
     bool delete_is_running;
 
     info_t() : _header(), rows_owned(NULL), max_owned_row_off(0),
@@ -391,13 +391,13 @@ public:
       delete append_list;
     }
   };
-  
+
   struct cond_expr_reset_pos_t {
     void operator()(struct info_t *info, cond_expr_t& e) const {
       e.pos = 0;
     }
   };
-  
+
   struct stats_t {
     my_off_t wait_immediate_cnt;
     my_off_t wait_delayed_cnt;
@@ -406,12 +406,12 @@ public:
     my_off_t close_cnt;
     stats_t() : wait_immediate_cnt(0), wait_delayed_cnt(0), wait_timeout_cnt(0), abort_cnt(0), close_cnt(0) {}
   };
-  
+
 private:
   uint ref_cnt;
   char *table_name;
   uint table_name_length;
-  
+
   /* mutex:         used for many purposes
      mmap_mutex:    used for blocking remapping
      rwlock:        used to block compaction
@@ -420,9 +420,9 @@ private:
    */
   pthread_mutex_t compact_mutex;
   pthread_rwlock_t rwlock;
-  
+
   THR_LOCK store_lock;
-  
+
 #ifdef Q4M_USE_MMAP
   struct mmap_info_t {
     char *ptr;
@@ -431,22 +431,22 @@ private:
   };
   cac_rwlock_t<mmap_info_t> map;
 #endif
-  
+
   int fd;
 public:
   cac_mutex_t<info_t> info;
   cac_mutex_t<stats_t> *stats;
 private:
   cond_expr_t cond_expr_true;
-  
+
   listener_list_t listener_list; /* access serialized using listener_mutex */
-  
+
   pthread_t writer_thread;
   bool writer_do_wake_listeners;
-  
+
   /* following fields are for V2 type table only */
   queue_fixed_field_t **fixed_fields_;
-  
+
 public:
   void recalc_row_count(info_t *info, bool log);
   bool fixup_header(info_t *info);
@@ -467,7 +467,7 @@ public:
   }
   void unregister_listener(listener_t *l);
   bool wake_listeners(bool from_writer = false);
-  
+
   const char *get_table_name() const { return table_name; }
   THR_LOCK *get_store_lock() { return &store_lock; }
   queue_fixed_field_t * const *get_fixed_fields() const {
@@ -559,7 +559,7 @@ class ha_queue: public handler
 {
   THR_LOCK_DATA lock;
   queue_share_t *share;
-  
+
   my_off_t pos;
   uchar *rows;
   size_t rows_size, rows_reserved;
@@ -571,7 +571,7 @@ class ha_queue: public handler
  public:
   ha_queue(handlerton *hton, TABLE_SHARE *table_arg);
   ~ha_queue();
-  
+
   const char *table_type() const {
     return "QUEUE";
   }
@@ -586,7 +586,7 @@ class ha_queue: public handler
     return HA_NO_TRANSACTIONS | HA_UNUSED3 | HA_CAN_GEOMETRY
 #endif
       | HA_STATS_RECORDS_IS_EXACT | HA_CAN_BIT_FIELD
-      /* | HA_BINLOG_ROW_CAPABLE | HA_BINLOG_STMT_CAPABLE */ 
+      /* | HA_BINLOG_ROW_CAPABLE | HA_BINLOG_STMT_CAPABLE */
       | HA_FILE_BASED | HA_NO_AUTO_INCREMENT
 #if MYSQL_VERSION_ID < 80000
       | HA_HAS_RECORDS;
@@ -598,7 +598,7 @@ class ha_queue: public handler
   ulong index_flags(uint, uint, bool) const {
     return 0;
   }
-  
+
 #if MYSQL_VERSION_ID < 80000
   int open(const char *name, int mode, uint test_if_locked);
 #else
@@ -611,7 +611,7 @@ class ha_queue: public handler
   int rnd_next(uchar *buf);
   int rnd_pos(uchar *buf, uchar *_pos);
   void position(const uchar *record);
-  
+
   int info(uint);
   ha_rows records();
 #if MYSQL_VERSION_ID < 80000
@@ -620,18 +620,24 @@ class ha_queue: public handler
   int create(const char *name, TABLE *form, HA_CREATE_INFO *create_info, dd::Table *table_def);
 #endif
 
+#if MYSQL_VERSION_ID < 80000
+  int rename_table(const char *from, const char *to);
+#else
+  int rename_table(const char *from, const char *to, const dd::Table *from_table_def, dd::Table *to_table_def);
+#endif
+
   THR_LOCK_DATA **store_lock(THD *thd, THR_LOCK_DATA **to,
                              enum thr_lock_type lock_type);     ///< required
 #if MYSQL_VERSION_ID < 80000
   uint8 table_cache_type() { return HA_CACHE_TBL_NOCACHE; }
 #endif
-  
+
   void start_bulk_insert(ha_rows rows);
   int end_bulk_insert();
-  
+
   bool start_bulk_delete();
   int end_bulk_delete();
-  
+
   int write_row(uchar *buf);
   int update_row(const uchar *old_data, uchar *new_data);
   int delete_row(const uchar *buf);

--- a/t/17-rename-table.t
+++ b/t/17-rename-table.t
@@ -1,0 +1,52 @@
+#! /usr/bin/env perl
+
+use strict;
+use warnings;
+
+use DBI;
+use Test::More tests => 9;
+
+sub dbi_connect {
+    DBI->connect(
+        $ENV{DBI} || 'dbi:mysql:database=test;host=localhost;mysql_socket=/var/lib/mysql/mysql.sock',
+        $ENV{DBI_USER} || 'root',
+        $ENV{DBI_PASSWORD} || '',
+    ) or die 'connection failed:';
+}
+
+my $dbh = dbi_connect();
+
+# Clean up any existing tables
+ok $dbh->do('drop table if exists q4m_old');
+ok $dbh->do('drop table if exists q4m_new');
+
+# Create a table with some data
+ok $dbh->do('create table q4m_old (v1 int not null, v2 int not null) engine=queue');
+ok $dbh->do("insert into q4m_old values (1,1), (2,2), (3,3)");
+
+# Verify the data is there
+is_deeply(
+    $dbh->selectall_arrayref(q{select * from q4m_old order by v1}),
+    [ [ 1, 1 ], [ 2, 2 ], [ 3, 3 ] ],
+    'data exists before rename'
+);
+
+# Rename the table
+ok $dbh->do('alter table q4m_old rename to q4m_new');
+
+# Verify the old table doesn't exist
+is_deeply(
+    $dbh->selectall_arrayref(q{show tables like 'q4m_old'}),
+    [],
+    'old table name does not exist'
+);
+
+# Verify the new table exists and has the same data
+is_deeply(
+    $dbh->selectall_arrayref(q{select * from q4m_new order by v1}),
+    [ [ 1, 1 ], [ 2, 2 ], [ 3, 3 ] ],
+    'new table has the same data'
+);
+
+# Clean up
+ok $dbh->do('drop table q4m_new');

--- a/t/18-rename-table-files.t
+++ b/t/18-rename-table-files.t
@@ -1,0 +1,59 @@
+#! /usr/bin/env perl
+
+use strict;
+use warnings;
+
+use DBI;
+use Test::More tests => 9;
+
+sub dbi_connect {
+    DBI->connect(
+        $ENV{DBI} || 'dbi:mysql:database=test;host=localhost;mysql_socket=/var/lib/mysql/mysql.sock',
+        $ENV{DBI_USER} || 'root',
+        $ENV{DBI_PASSWORD} || '',
+    ) or die 'connection failed:';
+}
+
+sub get_data_dir {
+    my $dbh = shift;
+    my $result = $dbh->selectall_arrayref("SHOW VARIABLES LIKE 'datadir'");
+    return $result->[0]->[1];
+}
+
+sub check_file_exists {
+    my ($data_dir, $db_name, $table_name, $ext) = @_;
+    my $file_path = "$data_dir/$db_name/$table_name$ext";
+    return -f $file_path;
+}
+
+my $dbh = dbi_connect();
+
+# Get the data directory
+my $data_dir = get_data_dir($dbh);
+my $db_name = 'test';  # Assuming we're using the 'test' database
+
+# Clean up any existing tables
+ok $dbh->do('drop table if exists q4m_rename_test');
+ok $dbh->do('drop table if exists q4m_renamed_test');
+
+# Create a table with some data
+ok $dbh->do('create table q4m_rename_test (v1 int not null) engine=queue');
+ok $dbh->do("insert into q4m_rename_test values (1), (2), (3)");
+
+# Verify the .Q4M file exists for the original table
+ok(check_file_exists($data_dir, $db_name, 'q4m_rename_test', '.Q4M'),
+   'Q4M file exists before rename');
+
+# Rename the table
+ok $dbh->do('alter table q4m_rename_test rename to q4m_renamed_test');
+
+# Verify the .Q4M file exists for the renamed table
+ok(check_file_exists($data_dir, $db_name, 'q4m_renamed_test', '.Q4M'),
+   'Q4M file exists after rename');
+
+# Verify the old .Q4M file doesn't exist
+ok(!check_file_exists($data_dir, $db_name, 'q4m_rename_test', '.Q4M'),
+   'Old Q4M file does not exist after rename');
+
+# Clean up
+ok $dbh->do('drop table q4m_renamed_test');


### PR DESCRIPTION
This pull request introduces a new `rename_table` method for the `ha_queue` storage engine, enabling the renaming of tables and ensuring compatibility with different MySQL versions. Additionally, it includes comprehensive test cases to validate the functionality. Below are the key changes:

### Implementation of `rename_table` Method:
* Added `rename_table` method in `ha_queue` to handle table renaming. The method ensures file existence checks, renames the data file, and manages table shares. It supports different method signatures based on MySQL version (`MYSQL_VERSION_ID`). (`src/ha_queue.cc`, [src/ha_queue.ccR2747-R2793](diffhunk://#diff-0d3e8c9ffc4b248ba542f46db215b64fa8206bf790772abbc4a572119ed2b9d2R2747-R2793))
* Declared the `rename_table` method in the `ha_queue` class definition with conditional compilation for MySQL version compatibility. (`src/ha_queue.h`, [src/ha_queue.hR623-R628](diffhunk://#diff-021f5170f92c60f1d8f8e076bf8f86a307f507f9a391f3db5ea3f88efa1b713bR623-R628))

### Test Cases for Table Renaming:
* Introduced `t/17-rename-table.t` to test the logical renaming of tables, verifying data integrity and table existence before and after renaming. (`t/17-rename-table.t`, [t/17-rename-table.tR1-R52](diffhunk://#diff-6ce8f63207722f4debb005232e897f693f185ff4e07d8902da3fa869c300ffedR1-R52))
* Added `t/18-rename-table-files.t` to validate the renaming of underlying `.Q4M` files, ensuring the old file is removed and the new file is created correctly. (`t/18-rename-table-files.t`, [t/18-rename-table-files.tR1-R59](diffhunk://#diff-c165f029f5c8e9848ee3e49b6b19807c42d4515d1b5e82a9ef5c65bc6decf837R1-R59))


### reproduce

- create a table and rename it

  ```
  mysql> show variables like 'datadir';
  +---------------+----------------------+
  | Variable_name | Value |
  +---------------+----------------------+
  | datadir | /usr/local/q4m/data/ |
  +---------------+----------------------+
  1 row in set (0.02 sec)
  mysql> create table q4m_old (v1 int not null, v2 int not null) engine=queue;
  Query OK, 0 rows affected (0.03 sec)

  mysql> alter table q4m_old rename to q4m_new;
  Query OK, 0 rows affected (0.02 sec)

  mysql> show create table q4m_new;
  ERROR 1194 (HY000): Table 'q4m_new' is marked as crashed and should be repaired
  mysql> show tables;
  +----------------+
  | Tables_in_test |
  +----------------+
  | q4m_new        |
  +----------------+
  1 row in set (0.01 sec)
  ```

- the .Q4M file isn't renamed
  ```
  [mysql@d98c672465d5 /]$ ls -ltr /usr/local/q4m/data/test/
  total 12
  -rw-r----- 1 mysql mysql 2412 Jul 23 01:38 q4m_old_364.sdi
  -rw-r----- 1 mysql mysql 4194304 Jul 23 01:38 q4m_old.Q4M
  [mysql@d98c672465d5 /]$ ls -ltr /usr/local/q4m/data/test/
  total 12
  -rw-r----- 1 mysql mysql 4194304 Jul 23 01:39 q4m_old.Q4M
  -rw-r----- 1 mysql mysql 2412 Jul 23 01:39 q4m_new_364.sdi
  ```


### test


- create a table and rename it

  ```
  mysql> create table q4m_old (v1 int not null, v2 int not null) engine=queue;
  Query OK, 0 rows affected (0.01 sec)

  mysql> alter table q4m_old rename to q4m_new;
  Query OK, 0 rows affected (0.01 sec)

  mysql> show create table q4m_new;
  +---------+----------------------------------------------------------------------------------------------------------+
  | Table | Create Table |
  +---------+----------------------------------------------------------------------------------------------------------+
  | q4m_new | CREATE TABLE `q4m_new` (
  `v1` int NOT NULL,
  `v2` int NOT NULL
  ) ENGINE=QUEUE DEFAULT CHARSET=utf8mb3 |
  +---------+----------------------------------------------------------------------------------------------------------+
  1 row in set (0.00 sec)

  mysql> show tables;
  +---------------+
  | Tables_in_foo |
  +---------------+
  | q4m_new |
  +---------------+
  1 row in set (0.00 sec)
  ```

- .Q4M is renamed as well
  ```
  root@64811adc4ba7:/# ls -ltr /var/lib/mysql/test/
  total 12
  -rw-r----- 1 mysql mysql    2412 Jul 23 01:47 q4m_old_363.sdi
  -rw-r----- 1 mysql mysql 4194304 Jul 23 01:47 q4m_old.Q4M
  root@64811adc4ba7:/# ls -ltr /var/lib/mysql/test/
  total 12
  -rw-r----- 1 mysql mysql    2412 Jul 23 01:47 q4m_new_363.sdi
  -rw-r----- 1 mysql mysql 4194304 Jul 23 01:47 q4m_new.Q4M
  ```


I've confirmed this patch can work `RENAME TABLE` correctly by test spec as well
```
root@fc833bf0d233:/tmp/q4m# ./run_tests.pl t/17-rename-table.t
t/17-rename-table.t .. ok
All tests successful.
Files=1, Tests=9,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.03 cusr  0.01 csys =  0.07 CPU)
Result: PASS
root@fc833bf0d233:/tmp/q4m# ./run_tests.pl t/18-rename-table-files.t
t/18-rename-table-files.t .. ok
All tests successful.
Files=1, Tests=9,  0 wallclock secs ( 0.01 usr  0.00 sys +  0.03 cusr  0.00 csys =  0.04 CPU)
Result: PASS
```